### PR TITLE
aligned_alloc is a C11 function but the code is C++ => problems on manylinux and maybe others

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ There are at least two python wrappers available for libCZI. They provide easy a
 
 #### AICSImageIO
 
-This library from the Allen Cell Institute for Cell Science uses libCZI among other tools to read CZI, OME-TIFF and TIFF images and can be found here: [AICSimageIO](https://allencellmodeling.github.io/aicsimageio/)
+This library from the Allen Institute for Cell Science uses libCZI among other tools to read CZI, OME-TIFF and TIFF images and can be found here: [AICSimageIO](https://allencellmodeling.github.io/aicsimageio/)
 
 #### pylibCZI
 

--- a/Src/libCZI/stdAllocator.cpp
+++ b/Src/libCZI/stdAllocator.cpp
@@ -30,7 +30,7 @@ void* CHeapAllocator::Allocate(std::uint64_t size)
 	{
 		throw std::out_of_range("The requested size for allocation is out-of-range.");
 	}
-#if defined(__EMSCRIPTEN__)||defined(__APPLE__)
+#if defined(__EMSCRIPTEN__)||defined(__APPLE__)||!defined(_ISOC11_SOURCE)
 	return malloc((size_t)size);
 #else
 #if defined(__GNUC__)
@@ -44,7 +44,7 @@ void* CHeapAllocator::Allocate(std::uint64_t size)
 
 void CHeapAllocator::Free(void* ptr)
 {
-#if defined(__GNUC__)||defined(__EMSCRIPTEN__)
+#if defined(__GNUC__)||defined(__EMSCRIPTEN__)||!defined(_ISOC11_SOURCE)
 	free(ptr);
 #else
 	_aligned_free(ptr);

--- a/Src/libCZI/stdAllocator.cpp
+++ b/Src/libCZI/stdAllocator.cpp
@@ -30,16 +30,13 @@ void* CHeapAllocator::Allocate(std::uint64_t size)
 	{
 		throw std::out_of_range("The requested size for allocation is out-of-range.");
 	}
-	// it's not clear to me why the code needs the returned pointer to be at a memory boundary
-	// meaning divisible by 32 in this case. I've preserved that functionality but restructured
-	// the code block to be more general.
 	// Compilation was failing on the original with linux distros that don't have the _ISOC11_SOURCE.
 #if defined(_WIN32)
 	return (void *)_aligned_malloc((size_t)size, 32);
 #elif defined(_ISOC11_SOURCE)
 	return aligned_alloc(32, size);
 #else
-	return ::operator new((size_t)size);
+	return malloc((size_t)size);
 #endif
 }
 
@@ -50,7 +47,7 @@ void CHeapAllocator::Free(void* ptr)
 #elif defined(_ISOC11_SOURCE)
     free(ptr);
 #else
-    ::operator delete(ptr);
+    free(ptr);
 #endif
 }
 


### PR DESCRIPTION
The initial code assumes that aligned_alloc is defined in C++ but aligned_alloc is part of the C11 standard and isn't incorporated into C++ until C++17.  To the best of my knowledge, the latest version of C++ that libCZI compiles against is C++14 because Eigen has a conflict with C++17.  To complicate matters further some variants of Linux define aligned_alloc in stdlib.h for their platform and it may also be defined in g++XX but I haven't investigated that. 

What this means: 
libCZI builds on Ubuntu, Arch-Linux, and Linux distro's that add aligned_alloc to cstdlib.h
Manylinux2010 which I believe is based off Centos 6 does not have aligned_alloc defined resulting in a failed build for any c++ based python extension. 
  
To remedy this issue I've simplified the conditional logic added and the condition `defined(_ISOC11_SOURCE)` to the `#if` statement in stdAllocator.cpp and defaulting to new and delete usage if aligned_alloc or WIN32's equivalent isn't defined. For the manylinux2010 case this seems to resolve the issue and allows compilation to work.